### PR TITLE
Fix xlsx templates web page file mapping error by sorting the templat…

### DIFF
--- a/config/templates.json
+++ b/config/templates.json
@@ -7,15 +7,15 @@
     },
     {
         "RS": "RS0002",
-        "keywords": {"performance_map_type": "DISCRETE"},
-        "file-name-suffix": "discrete-fan",
-        "description": "Unitary System with Discrete Fan"
-    },
-    {
-        "RS": "RS0002",
         "keywords": {"performance_map_type": "CONTINUOUS"},
         "file-name-suffix": "continuous-fan",
         "description": "Unitary System with Continuous Fan"
+    },
+    {
+        "RS": "RS0002",
+        "keywords": {"performance_map_type": "DISCRETE"},
+        "file-name-suffix": "discrete-fan",
+        "description": "Unitary System with Discrete Fan"
     },
     {
         "RS": "RS0003",

--- a/web/web-content.py
+++ b/web/web-content.py
@@ -158,6 +158,7 @@ def generate(web_dir):
     template_content = tk205.load(os.path.join(root_dir, "..", "config", "templates.json"))
 
     templates_page_data = OrderedDict()
+    templates_dictionary.sort()
     for index, template_file in enumerate(templates_dictionary):
         templates_page_data[template_file] = {'title':template_content[index]['RS'], 'description':template_content[index]['description'], 'template_file':template_file}
     generate_page(env, 'templates_template.html', 'templates.html', web_dir, 'XLSX Templates', templates_page_data)


### PR DESCRIPTION
This pull request fixes the mapping issue seen on the templates page of the open205 web content generated from the web-content.py script. The issue was that the xlsx template file links on the html page where not linking to the correct description. The source of this issue was that an unsorted dictionary was being used to build up the template page data. The solution is to simply sort the dictionary before building the page data.