### PR TITLE
change to 205 and SSPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,15 @@
 Toolkit 205
 ===========
 
-A toolkit to facilitate the adoption of the ASHRAE Standard 205P data exchange specification.
+A toolkit to facilitate the adoption of the ASHRAE Standard 205 data exchange specification.
 
 **Disclaimer:** While this toolkit is developed in conjunction with the ASHRAE Standard 205 project committee, it is not an official ASHRAE product or a part of the standard.
 
-**Warning!**  As the proposed ASHRAE Standard 205P has not yet been published, the content in this repository is subject to change and should be considered unstable for application development.
 
 About ASHRAE 205
 ----------------
 
-ASHRAE Standard 205P is "Standard Representation of Performance Simulation Data for HVAC&R and Other Facility Equipment". While the standard is not yet published, public reviews are available at [ASHRAE's online review portal](https://osr.ashrae.org/default.aspx).
+ASHRAE Standard 205 is "Standard Representation of Performance Simulation Data for HVAC&R and Other Facility Equipment". 
 
 The stated purpose of ASHRAE Standard 205 is:
 

--- a/web/markdown-content/about.md
+++ b/web/markdown-content/about.md
@@ -1,4 +1,4 @@
-# ASHRAE Standard 205P: Representation of Performance Data for HVAC&R and Other Facility Equipment
+# ASHRAE Standard 205: Representation of Performance Data for HVAC&R and Other Facility Equipment
 
 ## Purpose
 
@@ -8,11 +8,11 @@ To facilitate automated sharing of equipment performance characteristics by defi
 
 This standard applies to performance data for any HVAC&R or other facility system, equipment, or component.
 
-## About ASHRAE Standard 205P
+## About ASHRAE Standard 205
 
-ASHRAE Standard 205P defines common data models and serialization formats for facility equipment performance data needed for engineering applications such as energy simulation.  The formats allow automated exchange among data sources (manufacturers), simulation models, and other engineering applications. The formats and procedures specified in the standard are developed by SPC (Standard Project Committee) 205 under ASHRAE and ANSI consensus processes. SPC-205 membership includes equipment manufacturers, application software developers, and engineering practitioners.
+ASHRAE Standard 205 defines common data models and serialization formats for facility equipment performance data needed for engineering applications such as energy simulation.  The formats allow automated exchange among data sources (manufacturers), simulation models, and other engineering applications. The formats and procedures specified in the standard are developed by SSPC (Standing Standard Project Committee) 205 under ASHRAE and ANSI consensus processes. SSPC-205 membership includes equipment manufacturers, application software developers, and engineering practitioners.
 
-Standard 205 defines the term *representation* to mean a Concise Binary Object Representation (CBOR) file conforming to a JSON schema defined by a human-readable (text) document called a *representation specification*.  Representation specifications are included in Standard 205P appended as an open-ended set.
+Standard 205 defines the term *representation* to mean a Concise Binary Object Representation (CBOR) file conforming to a JSON schema defined by a human-readable (text) document called a *representation specification*.  Representation specifications are included in Standard 205 appended as an open-ended set.
 
 Standard 205 structure and application can be visualized as follows:
 
@@ -28,4 +28,4 @@ This web site hosts supporting material for each representation specification, i
 
 All representations have common structures and elements.  An open source project, [open205](https://github.com/open205), is underway to provide software components for use by data publishers and application developers.
 
-SPC 205 is developing representation specifications for additional equipment types.  These will be published in future revisions of the standard.
+SSPC 205 is developing representation specifications for additional equipment types.  These will be published in future revisions of the standard.

--- a/web/markdown-content/examples.md
+++ b/web/markdown-content/examples.md
@@ -1,4 +1,4 @@
-Examples provided here are for illustrative purposes only. While CBOR is the official representation format defined by ASHRAE Standard 205P, it is sometime convenient to view and edit representation data in other formats. All other file formats must be translated to CBOR for use in application software. Routines for converting between the file formats are included in [Toolkit 205](tk205.html).
+Examples provided here are for illustrative purposes only. While CBOR is the official representation format defined by ASHRAE Standard 205, it is sometime convenient to view and edit representation data in other formats. All other file formats must be translated to CBOR for use in application software. Routines for converting between the file formats are included in [Toolkit 205](tk205.html).
 
 Each example represntation is provided in four formats:
 

--- a/web/markdown-content/templates.md
+++ b/web/markdown-content/templates.md
@@ -1,1 +1,1 @@
-Templates set up in the XLSX format for users to generate 205 compliant data. These templates will need to be translated into CBOR, but can be validated directly using [Toolkit 205](tk205.html).
+Templates set up in the XLSX format for users to generate Standard 205 compliant data. These templates will need to be translated into CBOR, but can be validated directly using [Toolkit 205](tk205.html).

--- a/web/markdown-content/tk205.md
+++ b/web/markdown-content/tk205.md
@@ -1,1 +1,1 @@
-A software toolkit to facilitate the adoption of the ASHRAE Standard 205P data exchange specification.
+A software toolkit to facilitate the adoption of the ASHRAE Standard 205 data exchange specification.


### PR DESCRIPTION
Changed 205P to 205 and SPC to SSPC in the markdown templates for the webpages and the toolkit readme. This does not include readme's in the other repositories.